### PR TITLE
feat(provider-views): add metadata + improve metadata handling in Google Photos Picker

### DIFF
--- a/packages/@uppy/google-drive-picker/src/GoogleDrivePicker.tsx
+++ b/packages/@uppy/google-drive-picker/src/GoogleDrivePicker.tsx
@@ -76,7 +76,7 @@ export default class GoogleDrivePicker<M extends Meta, B extends Body>
     accessToken: string,
   ) => {
     this.uppy.addFiles(
-      files.map(({ id, mimeType, name, ...rest }) => {
+      files.map(({ id, mimeType, name, platform, ...rest }) => {
         return {
           source: this.id,
           name,
@@ -91,10 +91,14 @@ export default class GoogleDrivePicker<M extends Meta, B extends Body>
             body: {
               fileId: id,
               accessToken,
-              ...rest,
+              platform,
+              ...('url' in rest && { url: rest.url }),
             },
             requestClientId: GoogleDrivePicker.requestClientId,
           },
+          ...(('metadata' in rest && {
+            meta: rest.metadata,
+          }) as Meta), // dunno how to type this
         }
       }),
     )

--- a/packages/@uppy/google-photos-picker/src/GooglePhotosPicker.tsx
+++ b/packages/@uppy/google-photos-picker/src/GooglePhotosPicker.tsx
@@ -74,7 +74,7 @@ export default class GooglePhotosPicker<M extends Meta, B extends Body>
     accessToken: string,
   ) => {
     this.uppy.addFiles(
-      files.map(({ id, mimeType, name, ...rest }) => {
+      files.map(({ id, mimeType, name, platform, ...rest }) => {
         return {
           source: this.id,
           name,
@@ -89,10 +89,14 @@ export default class GooglePhotosPicker<M extends Meta, B extends Body>
             body: {
               fileId: id,
               accessToken,
-              ...rest,
+              platform,
+              ...('url' in rest && { url: rest.url }),
             },
             requestClientId: GooglePhotosPicker.requestClientId,
           },
+          ...(('metadata' in rest && {
+            meta: rest.metadata,
+          }) as Meta), // dunno how to type this
         }
       }),
     )

--- a/packages/@uppy/provider-views/src/GooglePicker/googlePicker.ts
+++ b/packages/@uppy/provider-views/src/GooglePicker/googlePicker.ts
@@ -6,6 +6,27 @@ export interface MediaItemBase {
   createTime: string
 }
 
+// Shared metadata interface to avoid duplication
+export interface MediaMetadata {
+  // Base metadata
+  createTime?: string
+  width?: number
+  height?: number
+  cameraMake?: string
+  cameraModel?: string
+
+  // Photo-specific metadata
+  focalLength?: number
+  apertureFNumber?: number
+  isoEquivalent?: number
+  exposureTime?: string
+
+  // Video-specific metadata
+  fps?: number
+  processingStatus?: 'UNSPECIFIED' | 'PROCESSING' | 'READY' | 'FAILED'
+}
+
+// Original interfaces kept for compatibility
 interface MediaFileMetadataBase {
   width: number
   height: number
@@ -77,21 +98,7 @@ export interface PickedDriveItem extends PickedItemBase {
 export interface PickedPhotosItem extends PickedItemBase {
   platform: 'photos'
   url: string
-  metadata?: {
-    createTime?: string
-    width?: number
-    height?: number
-    cameraMake?: string
-    cameraModel?: string
-    // Photo-specific metadata
-    focalLength?: number
-    apertureFNumber?: number
-    isoEquivalent?: number
-    exposureTime?: string
-    // Video-specific metadata
-    fps?: number
-    processingStatus?: 'UNSPECIFIED' | 'PROCESSING' | 'READY' | 'FAILED'
-  }
+  metadata?: MediaMetadata
 }
 
 export type PickedItem = PickedPhotosItem | PickedDriveItem
@@ -315,9 +322,9 @@ function extractMediaMetadata(
   mediaFile: MediaFileBase & { mediaFileMetadata?: any },
   type: 'PHOTO' | 'VIDEO' | 'TYPE_UNSPECIFIED',
   createTime?: string,
-): Record<string, any> {
+): MediaMetadata {
   // Base metadata with createTime (if available)
-  const baseMetadata: Record<string, any> = {}
+  const baseMetadata: MediaMetadata = {}
   if (createTime) {
     baseMetadata.createTime = createTime
   }
@@ -329,7 +336,7 @@ function extractMediaMetadata(
 
   // Add basic media metadata
   const { mediaFileMetadata } = mediaFile
-  const mediaMetadata = {
+  const mediaMetadata: MediaMetadata = {
     ...baseMetadata,
     width: mediaFileMetadata.width,
     height: mediaFileMetadata.height,
@@ -344,12 +351,10 @@ function extractMediaMetadata(
     mediaFileMetadata.photoMetadata
   ) {
     const { photoMetadata } = mediaFileMetadata
-    Object.assign(mediaMetadata, {
-      focalLength: photoMetadata.focalLength,
-      apertureFNumber: photoMetadata.apertureFNumber,
-      isoEquivalent: photoMetadata.isoEquivalent,
-      exposureTime: photoMetadata.exposureTime,
-    })
+    mediaMetadata.focalLength = photoMetadata.focalLength
+    mediaMetadata.apertureFNumber = photoMetadata.apertureFNumber
+    mediaMetadata.isoEquivalent = photoMetadata.isoEquivalent
+    mediaMetadata.exposureTime = photoMetadata.exposureTime
   }
 
   // Add video-specific metadata if available
@@ -359,10 +364,8 @@ function extractMediaMetadata(
     mediaFileMetadata.videoMetadata
   ) {
     const { videoMetadata } = mediaFileMetadata
-    Object.assign(mediaMetadata, {
-      fps: videoMetadata.fps,
-      processingStatus: videoMetadata.processingStatus,
-    })
+    mediaMetadata.fps = videoMetadata.fps
+    mediaMetadata.processingStatus = videoMetadata.processingStatus
   }
 
   return mediaMetadata


### PR DESCRIPTION
At our company, we're using Uppy as our file upload system, and we have validation logic that requires photos to meet minimum height and width requirements. To improve this process, I've enhanced the metadata handling for Google Photos picker to extract and organize all available metadata that Google provides.

**Changes Made:**
Improved Metadata Extraction: Updated the extractMediaMetadata function to more reliably extract metadata from photos and videos
Better Type Safety: Added proper TypeScript interfaces for photo and video metadata
Comprehensive Metadata Support: Now properly handling all metadata fields including:
Basic metadata: width, height, cameraMake, cameraModel
Photo-specific: focalLength, apertureFNumber, isoEquivalent, exposureTime
Video-specific: fps, processingStatus
Creation time

**Benefits :** 
This feature will help users by:

Reducing the need for custom EXIF parsing on the client side
Providing all Google-supplied metadata directly in the Uppy object
Making validation of image dimensions more reliable and efficient
Supporting workflows that need photo metadata (like camera information)

**Testing**
I've tested this enhancement with various types of photos and videos from Google Photos and confirmed that all available metadata is now properly extracted and included in the Uppy file object.